### PR TITLE
Sort currencies by name and exchange rate for better change generation

### DIFF
--- a/scripts/currency.js
+++ b/scripts/currency.js
@@ -59,7 +59,17 @@ function getManualSpheres() {
 
     currencies.find(value => value.name === "Diamond Mark").primary = true;
 
-    return currencies;
+    currencies.sort(function(a, b) {
+        if (a.name < b.name) {
+            return -1;
+        }
+        if (a.name > b.name) {
+            return 1;
+        }
+        return 0;
+    });
+
+    return currencies.sort((a, b) => b.exchangeRate - a.exchangeRate);
 }
 
 async function getCompendiumSpheres() {
@@ -85,7 +95,16 @@ async function getCompendiumSpheres() {
                 exchangeRate: itemData.system.price.value,
             });
         }
-        if(currencies.length > 0) return currencies;
+        currencies.sort(function(a, b) {
+            if (a.name < b.name) {
+                return -1;
+            }
+            if (a.name > b.name) {
+                return 1;
+            }
+            return 0;
+        });
+        if(currencies.length > 0) return currencies.sort((a, b) => b.exchangeRate - a.exchangeRate);
     }
     return null;
 }


### PR DESCRIPTION
I noticed that using the unsorted list of currencies made it so that the change returned from buying items from merchants was very strangely formatted and unpleasant (often giving a ton of emerald and heliodor chips instead of larger denominations, if I remember correctly.) This change sorts currencies alphabetically (mainly to make sure that diamond marks are always returned for single-mark values) and then sorts them by value, highest to lowest (to return the smallest possible number of spheres by going for high-value spheres first.) 